### PR TITLE
[DEV-21018] Update version to 9.4.7 to match CMP.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name='onefuse',
-    version='1.4.2',
+    version='9.4.7',
     author='Cloudbolt Software, Inc.',
     author_email='support@cloudbolt.io',
     description='OneFuse upstream provider package for Python',


### PR DESCRIPTION
As part of Lodgepole release, we want upstream components, when possible, to match the corresponding CMP version.