### PR TITLE
2022.3.2 updates

### DIFF
--- a/onefuse/__init__.py
+++ b/onefuse/__init__.py
@@ -4,5 +4,5 @@ OneFuse Python Module
 Enables the execution of OneFuse policies via Python
 """
 
-__version__ = "2022.3.1"
+__version__ = "2022.3.2"
 __credits__ = 'Cloudbolt Software, Inc.'

--- a/onefuse/admin.py
+++ b/onefuse/admin.py
@@ -966,6 +966,8 @@ class OneFuseManager(object):
             Set). Default: "value"
         """
         try:
+            if type(template) != str:
+                return template
             if template.find('{%') == -1 and template.find('{{') == -1:
                 return template
             json_template = {

--- a/onefuse/backups.py
+++ b/onefuse/backups.py
@@ -495,7 +495,7 @@ class BackupManager(object):
                 detail = response.json()["detail"]
             except:
                 self.ofm.logger.error('Response JSON detail cannot be '
-                                      'accessed', response=response)
+                                      f'accessed. response: {response}')
                 raise
             if detail == 'Not found.':
                 # This may happen when script is run against older

--- a/onefuse/cloudbolt_admin.py
+++ b/onefuse/cloudbolt_admin.py
@@ -170,6 +170,12 @@ class CbOneFuseManager(OneFuseManager):
                         from infrastructure.models import Environment
                         resource.environment = Environment.objects.filter(
                             name=rendered_value).first()
+                    elif rendered_key == 'cpu_cnt':
+                        resource.cpu_cnt = rendered_value
+                        resource.save()
+                    elif rendered_key == 'mem_size':
+                        resource.mem_size = rendered_value
+                        resource.save()
                     else:
                         try:
                             resource.set_value_for_custom_field(rendered_key,

--- a/onefuse/cloudbolt_admin.py
+++ b/onefuse/cloudbolt_admin.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from infrastructure.models import CustomField, Server
 
 if __name__ == '__main__':
@@ -171,10 +173,14 @@ class CbOneFuseManager(OneFuseManager):
                         resource.environment = Environment.objects.filter(
                             name=rendered_value).first()
                     elif rendered_key == 'cpu_cnt':
-                        resource.cpu_cnt = rendered_value
+                        self.logger.info(f'Setting cpu_cnt to: '
+                                         f'{rendered_value}')
+                        resource.cpu_cnt = int(rendered_value)
                         resource.save()
                     elif rendered_key == 'mem_size':
-                        resource.mem_size = rendered_value
+                        self.logger.info(f'Setting mem_size to: '
+                                         f'{rendered_value}')
+                        resource.mem_size = Decimal(rendered_value)
                         resource.save()
                     else:
                         try:
@@ -503,11 +509,10 @@ class Utilities(object):
         except Exception:
             pass
         try:
-            hardware_info[index_prop]["memoryMB"] = resource.mem_size * 1024
-        except Exception:
-            pass
-        try:
-            hardware_info[index_prop]["memoryGB"] = resource.mem_size
+            mem_gb = int(resource.mem_size)
+            mem_mb = mem_gb * 1024
+            hardware_info[index_prop]["memoryGB"] = mem_gb
+            hardware_info[index_prop]["memoryMB"] = mem_mb
         except Exception:
             pass
         try:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name='onefuse',
-    version='2022.3.1',
+    version='2022.3.2',
     author='Cloudbolt Software, Inc.',
     author_email='support@cloudbolt.io',
     description='OneFuse upstream provider package for Python',


### PR DESCRIPTION
Changes made: 
- Updated to account for cpu_cnt and mem_size variables being driven by the Property Toolkit in CloudBolt CMP
- Setting type for cpu_cnt to int, and mem_size to Decimal
- Updated render method to return any non-string inputs as the value that was passed in. This allows for support of other types (int, etc.) inside of Property Toolkit Property Set JSON payload. 