### PR TITLE
Added the fix to resolve the setuptools dependencies[CMP-2738]

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include build.py

--- a/build.py
+++ b/build.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..dist import Distribution
+
+from distutils.command.build import build as _build
+
+_ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}
+
+
+class build(_build):
+    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
+
+    # copy to avoid sharing the object with parent class
+    sub_commands = _build.sub_commands[:]
+
+
+class SubCommand(Protocol):
+    """In order to support editable installations (see :pep:`660`) all
+    build subcommands **SHOULD** implement this protocol. They also **MUST** inherit
+    from ``setuptools.Command``.
+
+    When creating an :pep:`editable wheel <660>`, ``setuptools`` will try to evaluate
+    custom ``build`` subcommands using the following procedure:
+
+    1. ``setuptools`` will set the ``editable_mode`` attribute to ``True``
+    2. ``setuptools`` will execute the ``run()`` command.
+
+       .. important::
+          Subcommands **SHOULD** take advantage of ``editable_mode=True`` to adequate
+          its behaviour or perform optimisations.
+
+          For example, if a subcommand doesn't need to generate an extra file and
+          all it does is to copy a source file into the build directory,
+          ``run()`` **SHOULD** simply "early return".
+
+          Similarly, if the subcommand creates files that would be placed alongside
+          Python files in the final distribution, during an editable install
+          the command **SHOULD** generate these files "in place" (i.e. write them to
+          the original source directory, instead of using the build directory).
+          Note that ``get_output_mapping()`` should reflect that and include mappings
+          for "in place" builds accordingly.
+
+    3. ``setuptools`` use any knowledge it can derive from the return values of
+       ``get_outputs()`` and ``get_output_mapping()`` to create an editable wheel.
+       When relevant ``setuptools`` **MAY** attempt to use file links based on the value
+       of ``get_output_mapping()``. Alternatively, ``setuptools`` **MAY** attempt to use
+       :doc:`import hooks <python:reference/import>` to redirect any attempt to import
+       to the directory with the original source code and other files built in place.
+
+    Please note that custom sub-commands **SHOULD NOT** rely on ``run()`` being
+    executed (or not) to provide correct return values for ``get_outputs()``,
+    ``get_output_mapping()`` or ``get_source_files()``. The ``get_*`` methods should
+    work independently of ``run()``.
+    """
+
+    editable_mode: bool = False
+    """Boolean flag that will be set to ``True`` when setuptools is used for an
+    editable installation (see :pep:`660`).
+    Implementations **SHOULD** explicitly set the default value of this attribute to
+    ``False``.
+    When subcommands run, they can use this flag to perform optimizations or change
+    their behaviour accordingly.
+    """
+
+    build_lib: str
+    """String representing the directory where the build artifacts should be stored,
+    e.g. ``build/lib``.
+    For example, if a distribution wants to provide a Python module named ``pkg.mod``,
+    then a corresponding file should be written to ``{build_lib}/package/module.py``.
+    A way of thinking about this is that the files saved under ``build_lib``
+    would be eventually copied to one of the directories in :obj:`site.PREFIXES`
+    upon installation.
+
+    A command that produces platform-independent files (e.g. compiling text templates
+    into Python functions), **CAN** initialize ``build_lib`` by copying its value from
+    the ``build_py`` command. On the other hand, a command that produces
+    platform-specific files **CAN** initialize ``build_lib`` by copying its value from
+    the ``build_ext`` command. In general this is done inside the ``finalize_options``
+    method with the help of the ``set_undefined_options`` command::
+
+        def finalize_options(self):
+            self.set_undefined_options("build_py", ("build_lib", "build_lib"))
+            ...
+    """
+
+    def initialize_options(self) -> None:
+        """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
+
+    def finalize_options(self) -> None:
+        """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
+
+    def run(self) -> None:
+        """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
+
+    def get_source_files(self) -> list[str]:
+        """
+        Return a list of all files that are used by the command to create the expected
+        outputs.
+        For example, if your build command transpiles Java files into Python, you should
+        list here all the Java files.
+        The primary purpose of this function is to help populating the ``sdist``
+        with all the files necessary to build the distribution.
+        All files should be strings relative to the project root directory.
+        """
+        ...
+
+    def get_outputs(self) -> list[str]:
+        """
+        Return a list of files intended for distribution as they would have been
+        produced by the build.
+        These files should be strings in the form of
+        ``"{build_lib}/destination/file/path"``.
+
+        .. note::
+           The return value of ``get_output()`` should include all files used as keys
+           in ``get_output_mapping()`` plus files that are generated during the build
+           and don't correspond to any source file already present in the project.
+        """
+        ...
+
+    def get_output_mapping(self) -> dict[str, str]:
+        """
+        Return a mapping between destination files as they would be produced by the
+        build (dict keys) into the respective existing (source) files (dict values).
+        Existing (source) files should be represented as strings relative to the project
+        root directory.
+        Destination files should be strings in the form of
+        ``"{build_lib}/destination/file/path"``.
+        """
+        ...

--- a/onefuse/__init__.py
+++ b/onefuse/__init__.py
@@ -4,5 +4,5 @@ OneFuse Python Module
 Enables the execution of OneFuse policies via Python
 """
 
-__version__ = "2023.1.1.1"
+__version__ = "2025.1.2"
 __credits__ = 'Cloudbolt Software, Inc.'

--- a/setup.py
+++ b/setup.py
@@ -1,62 +1,63 @@
-import sys
+import os
+import shutil
 import subprocess
 import logging
 
-
+# Set up logging configuration
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
-
-def get_setuptools_version():
+def get_setuptools_location():
     try:
-        # Run pip show setuptools and capture the output
+        # Get the location of setuptools.
         result = subprocess.run(
-            [sys.executable, "-m", "pip", "show", "setuptools"],
-            capture_output=True,
-            text=True,
-            check=True,
+            ['pip', 'show', 'setuptools'],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            text=True
         )
 
-        # Extract the version from the output
+        # If pip show failedd.
+        if result.returncode != 0:
+            log.error("Error: pip show setuptools failed.")
+            return None
+
+        # Extract the location of setuptools.
+        location = None
         for line in result.stdout.splitlines():
-            if line.startswith("Version:"):
-                version = line.split(":")[1].strip()
-                return version
+            if line.startswith('Location:'):
+                location = line.split(':')[1].strip()
+
+        if not location:
+            log.error("Error: Could not extract location of setuptools.")
+            return None
+
+        return location
+
+    except Exception as e:
+        log.error(f"Error extracting setuptools location: {e}")
         return None
-    except subprocess.CalledProcessError:
-        return None
 
 
-def ensure_setuptools():
-    setuptools_version = get_setuptools_version()
+target_directory = get_setuptools_location()
 
-    if setuptools_version == "75.6.0":
-        log.info(
-            f"setuptools version {setuptools_version} detected. Reinstalling it to resolve the dependecies"
-        )
+if target_directory:
+    # Construct the full path for the build.py.
+    build_file_path = os.path.join(target_directory, 'setuptools/command', 'build.py')
 
-        # Run pip install --force-reinstall for version 75.6.0
-        subprocess.check_call(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--force-reinstall",
-                "setuptools==75.6.0",
-            ]
-        )
-        log.info("setuptools 75.6.0 reinstalled successfully.")
-    elif setuptools_version:
-        log.info(f"setuptools version {setuptools_version} is up-to-date.")
-    else:
-        log.info("setuptools not found. Installing version 75.6.0...")
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "setuptools==75.6.0"]
-        )
+    try:
+        # Check if the build.py file already exists at the target location
+        if not os.path.exists(build_file_path):
+            shutil.copy('build.py', build_file_path)
+            print(f"build.py has been copied to {build_file_path}")
+        else:
+            print(f"build.py already exists at {build_file_path}, skipping creation.")
+    except FileNotFoundError as e:
+        print(f"Error: The file 'build.py' was not found in the current directory. {e}")
+    except Exception as e:
+        print(f"An error occurred while copying the file: {e}")
 
-
-ensure_setuptools()
+else:
+    print("Could not determine teh setuptools location. Skipping build.py creation.")
 
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,63 @@
+import sys
+import subprocess
+import logging
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger()
+
+
+def get_setuptools_version():
+    try:
+        # Run pip show setuptools and capture the output
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "show", "setuptools"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        # Extract the version from the output
+        for line in result.stdout.splitlines():
+            if line.startswith("Version:"):
+                version = line.split(":")[1].strip()
+                return version
+        return None
+    except subprocess.CalledProcessError:
+        return None
+
+
+def ensure_setuptools():
+    setuptools_version = get_setuptools_version()
+
+    if setuptools_version == "75.6.0":
+        log.info(
+            f"setuptools version {setuptools_version} detected. Reinstalling it to resolve the dependecies"
+        )
+
+        # Run pip install --force-reinstall for version 75.6.0
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--force-reinstall",
+                "setuptools==75.6.0",
+            ]
+        )
+        log.info("setuptools 75.6.0 reinstalled successfully.")
+    elif setuptools_version:
+        log.info(f"setuptools version {setuptools_version} is up-to-date.")
+    else:
+        log.info("setuptools not found. Installing version 75.6.0...")
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "setuptools==75.6.0"]
+        )
+
+
+ensure_setuptools()
+
 from setuptools import setup
 
 with open("README.rst", "r") as fh:
@@ -5,7 +65,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name='onefuse',
-    version='2023.1.1.1',
+    version='2025.1.2',
     author='Cloudbolt Software, Inc.',
     author_email='support@cloudbolt.io',
     description='OneFuse upstream provider package for Python',


### PR DESCRIPTION
The latest build includes the required setuptools version 75.6.0. however, the build module is missing from the package.
Added the fix to resolve the dependencies while installing the OneFuse package itself.